### PR TITLE
[Feat] 스토리보드로 구획을 잡았습니다

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,5 @@
 # SwiftLint 규칙 파일
 
 # 적용받지 않을 규칙
-
+disabled_rules:
+- force_cast # 스토리보드 IBOutlet, IBAction용

--- a/SnoopClass-IKEA.xcodeproj/project.pbxproj
+++ b/SnoopClass-IKEA.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		C50A26B228E8473900DEB0ED /* ikeaSearchViewMockData.json in Resources */ = {isa = PBXBuildFile; fileRef = C50A26B128E8473900DEB0ED /* ikeaSearchViewMockData.json */; };
 		C50A26B428E98A8F00DEB0ED /* MockupModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50A26B328E98A8F00DEB0ED /* MockupModel.swift */; };
 		C50A26B828E9B00300DEB0ED /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50A26B728E9B00300DEB0ED /* TabBarController.swift */; };
+		C590CC0728F5ACD900B9D551 /* SmallClasses.swift in Sources */ = {isa = PBXBuildFile; fileRef = C590CC0628F5ACD900B9D551 /* SmallClasses.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +33,7 @@
 		C50A26B128E8473900DEB0ED /* ikeaSearchViewMockData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ikeaSearchViewMockData.json; sourceTree = "<group>"; };
 		C50A26B328E98A8F00DEB0ED /* MockupModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockupModel.swift; sourceTree = "<group>"; };
 		C50A26B728E9B00300DEB0ED /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
+		C590CC0628F5ACD900B9D551 /* SmallClasses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallClasses.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,6 +77,7 @@
 				C50A26B128E8473900DEB0ED /* ikeaSearchViewMockData.json */,
 				C50A26B328E98A8F00DEB0ED /* MockupModel.swift */,
 				C50A26B728E9B00300DEB0ED /* TabBarController.swift */,
+				C590CC0628F5ACD900B9D551 /* SmallClasses.swift */,
 			);
 			path = "SnoopClass-IKEA";
 			sourceTree = "<group>";
@@ -174,6 +177,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C590CC0728F5ACD900B9D551 /* SmallClasses.swift in Sources */,
 				C50A26B428E98A8F00DEB0ED /* MockupModel.swift in Sources */,
 				C50A269D28E7EF7F00DEB0ED /* SearchViewController.swift in Sources */,
 				C50A269928E7EF7F00DEB0ED /* AppDelegate.swift in Sources */,

--- a/SnoopClass-IKEA/Base.lproj/Main.storyboard
+++ b/SnoopClass-IKEA/Base.lproj/Main.storyboard
@@ -23,10 +23,226 @@
             </objects>
             <point key="canvasLocation" x="6" y="-2"/>
         </scene>
+        <!--Search View Controller-->
+        <scene sceneID="d8U-GU-o2D">
+            <objects>
+                <viewController storyboardIdentifier="SearchViewController" id="3h8-ht-Mxw" customClass="SearchViewController" customModule="SnoopClass_IKEA" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="yrt-xX-aDz">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MPc-W7-LH6" userLabel="VerticalScrollView">
+                                <rect key="frame" x="0.0" y="47" width="390" height="763"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3Yk-18-p8n" userLabel="ContentView">
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="900"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EiS-hE-JsV" userLabel="VerticalStackView">
+                                                <rect key="frame" x="0.0" y="0.0" width="390" height="900"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KBh-zB-ivQ" userLabel="SearchSection">
+                                                        <rect key="frame" x="0.0" y="0.0" width="390" height="150"/>
+                                                        <color key="backgroundColor" systemColor="systemGreenColor"/>
+                                                        <gestureRecognizers/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="150" id="GZz-dE-Tx9"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sk8-3T-ZZd" userLabel="RecentSection">
+                                                        <rect key="frame" x="0.0" y="150" width="390" height="150"/>
+                                                        <subviews>
+                                                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sQA-Ei-wcw" userLabel="RecentScrollView">
+                                                                <rect key="frame" x="0.0" y="0.0" width="390" height="150"/>
+                                                                <subviews>
+                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xNN-qO-TFr" userLabel="RecentContentView">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="500" height="150"/>
+                                                                        <subviews>
+                                                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9K7-56-rqG">
+                                                                                <rect key="frame" x="0.0" y="0.0" width="500" height="150"/>
+                                                                                <subviews>
+                                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WQx-Wh-iO6">
+                                                                                        <rect key="frame" x="0.0" y="0.0" width="250" height="150"/>
+                                                                                        <color key="backgroundColor" systemColor="systemPinkColor"/>
+                                                                                        <constraints>
+                                                                                            <constraint firstAttribute="width" constant="250" id="Ru5-bX-hPO"/>
+                                                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="250" id="vcA-3o-6Qo"/>
+                                                                                        </constraints>
+                                                                                    </view>
+                                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bbE-Ka-sez">
+                                                                                        <rect key="frame" x="250" y="0.0" width="250" height="150"/>
+                                                                                        <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                                                                                        <constraints>
+                                                                                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="250" id="RM1-by-Oa7"/>
+                                                                                            <constraint firstAttribute="width" constant="250" id="irH-OO-cqM"/>
+                                                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="250" id="zOX-UL-sbU"/>
+                                                                                        </constraints>
+                                                                                    </view>
+                                                                                </subviews>
+                                                                            </stackView>
+                                                                        </subviews>
+                                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="width" priority="250" constant="390" id="K1k-AH-APh"/>
+                                                                            <constraint firstItem="9K7-56-rqG" firstAttribute="top" secondItem="xNN-qO-TFr" secondAttribute="top" id="f7E-tu-34Q"/>
+                                                                            <constraint firstItem="9K7-56-rqG" firstAttribute="leading" secondItem="xNN-qO-TFr" secondAttribute="leading" id="hYu-O3-YmX"/>
+                                                                            <constraint firstAttribute="trailing" secondItem="9K7-56-rqG" secondAttribute="trailing" id="o8D-Lu-6b9"/>
+                                                                            <constraint firstAttribute="bottom" secondItem="9K7-56-rqG" secondAttribute="bottom" id="s67-tg-kdH"/>
+                                                                        </constraints>
+                                                                    </view>
+                                                                </subviews>
+                                                                <constraints>
+                                                                    <constraint firstItem="xNN-qO-TFr" firstAttribute="bottom" secondItem="Hf0-Ak-1k5" secondAttribute="bottom" constant="150" id="Axa-Mu-QNn"/>
+                                                                    <constraint firstItem="xNN-qO-TFr" firstAttribute="leading" secondItem="sQA-Ei-wcw" secondAttribute="leading" id="MVh-bW-r4P"/>
+                                                                    <constraint firstItem="8wm-Oq-lQZ" firstAttribute="bottom" secondItem="xNN-qO-TFr" secondAttribute="bottom" id="Nyg-xy-ETp"/>
+                                                                    <constraint firstItem="xNN-qO-TFr" firstAttribute="height" secondItem="8wm-Oq-lQZ" secondAttribute="height" id="ShB-lH-DUy"/>
+                                                                    <constraint firstItem="xNN-qO-TFr" firstAttribute="top" secondItem="8wm-Oq-lQZ" secondAttribute="top" id="gWS-9a-A5G"/>
+                                                                    <constraint firstItem="xNN-qO-TFr" firstAttribute="width" secondItem="Hf0-Ak-1k5" secondAttribute="width" id="hkr-wP-pPK"/>
+                                                                    <constraint firstItem="xNN-qO-TFr" firstAttribute="top" secondItem="Hf0-Ak-1k5" secondAttribute="top" id="ssu-fX-e80"/>
+                                                                    <constraint firstAttribute="width" priority="250" constant="390" id="uUP-YX-uPY"/>
+                                                                </constraints>
+                                                                <viewLayoutGuide key="contentLayoutGuide" id="Hf0-Ak-1k5"/>
+                                                                <viewLayoutGuide key="frameLayoutGuide" id="8wm-Oq-lQZ"/>
+                                                            </scrollView>
+                                                        </subviews>
+                                                        <color key="backgroundColor" systemColor="systemBlueColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="150" id="2pU-1g-SbI"/>
+                                                            <constraint firstAttribute="bottom" secondItem="sQA-Ei-wcw" secondAttribute="bottom" id="EIb-Nr-Wfk"/>
+                                                            <constraint firstItem="sQA-Ei-wcw" firstAttribute="leading" secondItem="sk8-3T-ZZd" secondAttribute="leading" id="RWx-WF-aAN"/>
+                                                            <constraint firstItem="sQA-Ei-wcw" firstAttribute="top" secondItem="sk8-3T-ZZd" secondAttribute="top" id="xIg-lh-uLx"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ABm-ha-DRq">
+                                                        <rect key="frame" x="0.0" y="300" width="390" height="150"/>
+                                                        <color key="backgroundColor" systemColor="systemCyanColor"/>
+                                                        <gestureRecognizers/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="150" id="7BP-h4-UGc"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nu6-g0-jRM" userLabel="View3">
+                                                        <rect key="frame" x="0.0" y="450" width="390" height="150"/>
+                                                        <color key="backgroundColor" systemColor="systemYellowColor"/>
+                                                        <gestureRecognizers/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="150" id="9EN-WU-vg6"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GgM-Yc-UlN" userLabel="View4">
+                                                        <rect key="frame" x="0.0" y="600" width="390" height="150"/>
+                                                        <color key="backgroundColor" systemColor="systemTealColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="150" id="UY2-ed-AdS"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8hN-Ud-NAs" userLabel="View5">
+                                                        <rect key="frame" x="0.0" y="750" width="390" height="150"/>
+                                                        <color key="backgroundColor" systemColor="systemRedColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="150" id="2kf-hS-TMx"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstItem="EiS-hE-JsV" firstAttribute="leading" secondItem="3Yk-18-p8n" secondAttribute="leading" id="HtZ-Wi-SEg"/>
+                                            <constraint firstAttribute="trailing" secondItem="EiS-hE-JsV" secondAttribute="trailing" id="Mdj-bR-Xut"/>
+                                            <constraint firstAttribute="height" priority="250" constant="750" id="Si6-by-hz4"/>
+                                            <constraint firstItem="EiS-hE-JsV" firstAttribute="top" secondItem="3Yk-18-p8n" secondAttribute="top" id="oKQ-VH-GMK"/>
+                                            <constraint firstAttribute="bottom" secondItem="EiS-hE-JsV" secondAttribute="bottom" id="tCr-rR-DUW"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="jtQ-ae-ryS" firstAttribute="trailing" secondItem="3Yk-18-p8n" secondAttribute="trailing" id="7Gi-Pk-Mvd"/>
+                                    <constraint firstItem="3Yk-18-p8n" firstAttribute="leading" secondItem="0dx-ET-Ofe" secondAttribute="leading" id="FsW-69-M0M"/>
+                                    <constraint firstItem="3Yk-18-p8n" firstAttribute="trailing" secondItem="0dx-ET-Ofe" secondAttribute="trailing" id="HLt-bR-v6k"/>
+                                    <constraint firstItem="3Yk-18-p8n" firstAttribute="top" secondItem="MPc-W7-LH6" secondAttribute="top" id="PG9-55-Ka8"/>
+                                    <constraint firstItem="3Yk-18-p8n" firstAttribute="height" secondItem="0dx-ET-Ofe" secondAttribute="height" id="dDY-mA-5Pi"/>
+                                    <constraint firstItem="3Yk-18-p8n" firstAttribute="leading" secondItem="jtQ-ae-ryS" secondAttribute="leading" id="dux-um-nyJ"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="0dx-ET-Ofe"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="jtQ-ae-ryS"/>
+                            </scrollView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Xe-Z7-DZD"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="6Xe-Z7-DZD" firstAttribute="bottom" secondItem="MPc-W7-LH6" secondAttribute="bottom" id="3W1-fU-cnu"/>
+                            <constraint firstItem="MPc-W7-LH6" firstAttribute="leading" secondItem="6Xe-Z7-DZD" secondAttribute="leading" id="CEd-20-iZi"/>
+                            <constraint firstItem="6Xe-Z7-DZD" firstAttribute="trailing" secondItem="MPc-W7-LH6" secondAttribute="trailing" id="Uei-mO-o8d"/>
+                            <constraint firstItem="MPc-W7-LH6" firstAttribute="top" secondItem="6Xe-Z7-DZD" secondAttribute="top" id="mhG-uI-gK3"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="4gV-6w-TSF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="840" y="-10.663507109004739"/>
+        </scene>
+        <!--VC3-->
+        <scene sceneID="I1o-BO-LQP">
+            <objects>
+                <viewController storyboardIdentifier="VC3" id="hex-k1-LkG" customClass="VC3" customModule="SnoopClass_IKEA" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="T2L-Ay-Hq4">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="asdfasdfsadf" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZWQ-h3-AGa">
+                                <rect key="frame" x="0.0" y="418.33333333333331" width="390" height="20.333333333333314"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="hKl-k1-pTn"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="rvg-fb-vpR"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="ZWQ-h3-AGa" firstAttribute="centerY" secondItem="rvg-fb-vpR" secondAttribute="centerY" id="OLZ-RT-Z5u"/>
+                            <constraint firstItem="ZWQ-h3-AGa" firstAttribute="leading" secondItem="rvg-fb-vpR" secondAttribute="leading" id="Xps-xb-0Ye"/>
+                            <constraint firstItem="rvg-fb-vpR" firstAttribute="trailing" secondItem="ZWQ-h3-AGa" secondAttribute="trailing" id="gek-1e-3lI"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="textlabel" destination="ZWQ-h3-AGa" id="5Ih-uT-1MH"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="hTx-Ep-TUN" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1760" y="-26.303317535545023"/>
+        </scene>
     </scenes>
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBlueColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemCyanColor">
+            <color red="0.19607843137254902" green="0.67843137254901964" blue="0.90196078431372551" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemGreenColor">
+            <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemOrangeColor">
+            <color red="1" green="0.58431372549019611" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemPinkColor">
+            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemRedColor">
+            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemTealColor">
+            <color red="0.18823529411764706" green="0.69019607843137254" blue="0.7803921568627451" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemYellowColor">
+            <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/SnoopClass-IKEA/Base.lproj/Main.storyboard
+++ b/SnoopClass-IKEA/Base.lproj/Main.storyboard
@@ -28,11 +28,11 @@
             <objects>
                 <viewController storyboardIdentifier="SearchViewController" id="3h8-ht-Mxw" customClass="SearchViewController" customModule="SnoopClass_IKEA" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="yrt-xX-aDz">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="1042"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MPc-W7-LH6" userLabel="VerticalScrollView">
-                                <rect key="frame" x="0.0" y="47" width="390" height="763"/>
+                                <rect key="frame" x="0.0" y="47" width="390" height="961"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3Yk-18-p8n" userLabel="ContentView">
                                         <rect key="frame" x="0.0" y="0.0" width="390" height="900"/>
@@ -42,85 +42,163 @@
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KBh-zB-ivQ" userLabel="SearchSection">
                                                         <rect key="frame" x="0.0" y="0.0" width="390" height="150"/>
+                                                        <subviews>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="PTd-Xq-qYH">
+                                                                <rect key="frame" x="0.0" y="0.0" width="390" height="150"/>
+                                                                <subviews>
+                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ktr-Zg-0dY" userLabel="SearchTitleView">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="390" height="50"/>
+                                                                        <subviews>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="검색" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cFb-1P-XAF">
+                                                                                <rect key="frame" x="8" y="8" width="59" height="34"/>
+                                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                                                                <nil key="textColor"/>
+                                                                                <nil key="highlightedColor"/>
+                                                                            </label>
+                                                                        </subviews>
+                                                                        <color key="backgroundColor" systemColor="systemCyanColor"/>
+                                                                        <gestureRecognizers/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="cFb-1P-XAF" secondAttribute="trailing" constant="8" id="41V-hC-3wp"/>
+                                                                            <constraint firstItem="cFb-1P-XAF" firstAttribute="leading" secondItem="Ktr-Zg-0dY" secondAttribute="leadingMargin" id="BbL-sW-C9A"/>
+                                                                            <constraint firstItem="cFb-1P-XAF" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Ktr-Zg-0dY" secondAttribute="top" constant="8" id="SEg-nm-p4u"/>
+                                                                            <constraint firstAttribute="height" priority="750" constant="50" id="r8W-oY-Ao7"/>
+                                                                            <constraint firstAttribute="bottomMargin" secondItem="cFb-1P-XAF" secondAttribute="bottom" id="x7t-Pp-uVh"/>
+                                                                        </constraints>
+                                                                    </view>
+                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6Wi-oD-PwQ" userLabel="SearchBarView">
+                                                                        <rect key="frame" x="0.0" y="50" width="390" height="100"/>
+                                                                        <color key="backgroundColor" systemColor="systemGreenColor"/>
+                                                                        <gestureRecognizers/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" priority="250" constant="100" id="9N6-YK-Eka"/>
+                                                                        </constraints>
+                                                                    </view>
+                                                                </subviews>
+                                                            </stackView>
+                                                        </subviews>
                                                         <color key="backgroundColor" systemColor="systemGreenColor"/>
                                                         <gestureRecognizers/>
                                                         <constraints>
+                                                            <constraint firstItem="PTd-Xq-qYH" firstAttribute="leading" secondItem="KBh-zB-ivQ" secondAttribute="leading" id="8h0-Lw-cva"/>
                                                             <constraint firstAttribute="height" constant="150" id="GZz-dE-Tx9"/>
+                                                            <constraint firstItem="PTd-Xq-qYH" firstAttribute="top" secondItem="KBh-zB-ivQ" secondAttribute="top" id="TFW-wy-BvW"/>
+                                                            <constraint firstAttribute="trailing" secondItem="PTd-Xq-qYH" secondAttribute="trailing" id="Wh4-LV-eWC"/>
+                                                            <constraint firstAttribute="bottom" secondItem="PTd-Xq-qYH" secondAttribute="bottom" id="sTK-NV-y4q"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sk8-3T-ZZd" userLabel="RecentSection">
                                                         <rect key="frame" x="0.0" y="150" width="390" height="150"/>
                                                         <subviews>
-                                                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sQA-Ei-wcw" userLabel="RecentScrollView">
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="nnM-J6-6M5" userLabel="SubStackView">
                                                                 <rect key="frame" x="0.0" y="0.0" width="390" height="150"/>
                                                                 <subviews>
-                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xNN-qO-TFr" userLabel="RecentContentView">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="500" height="150"/>
+                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ABm-ha-DRq" userLabel="RecentTitleView">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="390" height="50"/>
                                                                         <subviews>
-                                                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9K7-56-rqG">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="500" height="150"/>
-                                                                                <subviews>
-                                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WQx-Wh-iO6">
-                                                                                        <rect key="frame" x="0.0" y="0.0" width="250" height="150"/>
-                                                                                        <color key="backgroundColor" systemColor="systemPinkColor"/>
-                                                                                        <constraints>
-                                                                                            <constraint firstAttribute="width" constant="250" id="Ru5-bX-hPO"/>
-                                                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="250" id="vcA-3o-6Qo"/>
-                                                                                        </constraints>
-                                                                                    </view>
-                                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bbE-Ka-sez">
-                                                                                        <rect key="frame" x="250" y="0.0" width="250" height="150"/>
-                                                                                        <color key="backgroundColor" systemColor="systemOrangeColor"/>
-                                                                                        <constraints>
-                                                                                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="250" id="RM1-by-Oa7"/>
-                                                                                            <constraint firstAttribute="width" constant="250" id="irH-OO-cqM"/>
-                                                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="250" id="zOX-UL-sbU"/>
-                                                                                        </constraints>
-                                                                                    </view>
-                                                                                </subviews>
-                                                                            </stackView>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="최근 본 제품" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9r0-Gb-j21">
+                                                                                <rect key="frame" x="8" y="15.666666666666655" width="105.33333333333333" height="26.333333333333329"/>
+                                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                                                <nil key="textColor"/>
+                                                                                <nil key="highlightedColor"/>
+                                                                            </label>
+                                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="bottom" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8qY-dy-tSr">
+                                                                                <rect key="frame" x="326" y="12" width="56" height="30"/>
+                                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                                                <color key="tintColor" systemColor="secondaryLabelColor"/>
+                                                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                                                <state key="normal" title="모두 삭제">
+                                                                                    <color key="titleColor" systemColor="secondaryLabelColor"/>
+                                                                                </state>
+                                                                            </button>
                                                                         </subviews>
-                                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                        <color key="backgroundColor" systemColor="systemPurpleColor"/>
+                                                                        <gestureRecognizers/>
                                                                         <constraints>
-                                                                            <constraint firstAttribute="width" priority="250" constant="390" id="K1k-AH-APh"/>
-                                                                            <constraint firstItem="9K7-56-rqG" firstAttribute="top" secondItem="xNN-qO-TFr" secondAttribute="top" id="f7E-tu-34Q"/>
-                                                                            <constraint firstItem="9K7-56-rqG" firstAttribute="leading" secondItem="xNN-qO-TFr" secondAttribute="leading" id="hYu-O3-YmX"/>
-                                                                            <constraint firstAttribute="trailing" secondItem="9K7-56-rqG" secondAttribute="trailing" id="o8D-Lu-6b9"/>
-                                                                            <constraint firstAttribute="bottom" secondItem="9K7-56-rqG" secondAttribute="bottom" id="s67-tg-kdH"/>
+                                                                            <constraint firstItem="9r0-Gb-j21" firstAttribute="leading" secondItem="ABm-ha-DRq" secondAttribute="leadingMargin" id="1fJ-Fs-W5Q"/>
+                                                                            <constraint firstAttribute="trailingMargin" secondItem="8qY-dy-tSr" secondAttribute="trailing" id="3tG-IR-YH9"/>
+                                                                            <constraint firstAttribute="height" constant="50" id="7BP-h4-UGc"/>
+                                                                            <constraint firstItem="9r0-Gb-j21" firstAttribute="top" relation="greaterThanOrEqual" secondItem="ABm-ha-DRq" secondAttribute="topMargin" id="9px-HQ-s7G"/>
+                                                                            <constraint firstItem="8qY-dy-tSr" firstAttribute="bottom" secondItem="ABm-ha-DRq" secondAttribute="bottomMargin" id="Skb-LG-rqw"/>
+                                                                            <constraint firstItem="8qY-dy-tSr" firstAttribute="top" relation="greaterThanOrEqual" secondItem="ABm-ha-DRq" secondAttribute="topMargin" id="ZYy-KP-6CY"/>
+                                                                            <constraint firstItem="8qY-dy-tSr" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="9r0-Gb-j21" secondAttribute="trailing" constant="20" id="lwP-Cn-V1E"/>
+                                                                            <constraint firstItem="9r0-Gb-j21" firstAttribute="bottom" secondItem="ABm-ha-DRq" secondAttribute="bottomMargin" id="oO1-cR-bAx"/>
                                                                         </constraints>
                                                                     </view>
+                                                                    <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sQA-Ei-wcw" userLabel="RecentScrollView">
+                                                                        <rect key="frame" x="0.0" y="50" width="390" height="100"/>
+                                                                        <subviews>
+                                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xNN-qO-TFr" userLabel="RecentContentView">
+                                                                                <rect key="frame" x="0.0" y="0.0" width="500" height="100"/>
+                                                                                <subviews>
+                                                                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9K7-56-rqG">
+                                                                                        <rect key="frame" x="0.0" y="0.0" width="500" height="100"/>
+                                                                                        <subviews>
+                                                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WQx-Wh-iO6">
+                                                                                                <rect key="frame" x="0.0" y="0.0" width="250" height="100"/>
+                                                                                                <color key="backgroundColor" systemColor="systemPinkColor"/>
+                                                                                                <constraints>
+                                                                                                    <constraint firstAttribute="width" constant="250" id="Ru5-bX-hPO"/>
+                                                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="250" id="vcA-3o-6Qo"/>
+                                                                                                </constraints>
+                                                                                            </view>
+                                                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bbE-Ka-sez">
+                                                                                                <rect key="frame" x="250" y="0.0" width="250" height="100"/>
+                                                                                                <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                                                                                                <constraints>
+                                                                                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="250" id="RM1-by-Oa7"/>
+                                                                                                    <constraint firstAttribute="width" constant="250" id="irH-OO-cqM"/>
+                                                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="250" id="zOX-UL-sbU"/>
+                                                                                                </constraints>
+                                                                                            </view>
+                                                                                        </subviews>
+                                                                                    </stackView>
+                                                                                </subviews>
+                                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                                <constraints>
+                                                                                    <constraint firstAttribute="width" priority="250" constant="390" id="K1k-AH-APh"/>
+                                                                                    <constraint firstAttribute="height" constant="100" id="Xet-Xv-di9"/>
+                                                                                    <constraint firstItem="9K7-56-rqG" firstAttribute="top" secondItem="xNN-qO-TFr" secondAttribute="top" id="f7E-tu-34Q"/>
+                                                                                    <constraint firstItem="9K7-56-rqG" firstAttribute="leading" secondItem="xNN-qO-TFr" secondAttribute="leading" id="hYu-O3-YmX"/>
+                                                                                    <constraint firstAttribute="trailing" secondItem="9K7-56-rqG" secondAttribute="trailing" id="o8D-Lu-6b9"/>
+                                                                                    <constraint firstAttribute="bottom" secondItem="9K7-56-rqG" secondAttribute="bottom" id="s67-tg-kdH"/>
+                                                                                </constraints>
+                                                                            </view>
+                                                                        </subviews>
+                                                                        <constraints>
+                                                                            <constraint firstItem="xNN-qO-TFr" firstAttribute="bottom" secondItem="Hf0-Ak-1k5" secondAttribute="bottom" id="Axa-Mu-QNn"/>
+                                                                            <constraint firstItem="xNN-qO-TFr" firstAttribute="leading" secondItem="sQA-Ei-wcw" secondAttribute="leading" id="MVh-bW-r4P"/>
+                                                                            <constraint firstItem="8wm-Oq-lQZ" firstAttribute="bottom" secondItem="xNN-qO-TFr" secondAttribute="bottom" id="Nyg-xy-ETp"/>
+                                                                            <constraint firstItem="xNN-qO-TFr" firstAttribute="height" secondItem="8wm-Oq-lQZ" secondAttribute="height" id="ShB-lH-DUy"/>
+                                                                            <constraint firstItem="xNN-qO-TFr" firstAttribute="top" secondItem="8wm-Oq-lQZ" secondAttribute="top" id="gWS-9a-A5G"/>
+                                                                            <constraint firstItem="xNN-qO-TFr" firstAttribute="width" secondItem="Hf0-Ak-1k5" secondAttribute="width" id="hkr-wP-pPK"/>
+                                                                            <constraint firstItem="xNN-qO-TFr" firstAttribute="top" secondItem="Hf0-Ak-1k5" secondAttribute="top" id="ssu-fX-e80"/>
+                                                                            <constraint firstAttribute="width" priority="250" constant="390" id="uUP-YX-uPY"/>
+                                                                        </constraints>
+                                                                        <viewLayoutGuide key="contentLayoutGuide" id="Hf0-Ak-1k5"/>
+                                                                        <viewLayoutGuide key="frameLayoutGuide" id="8wm-Oq-lQZ"/>
+                                                                    </scrollView>
                                                                 </subviews>
-                                                                <constraints>
-                                                                    <constraint firstItem="xNN-qO-TFr" firstAttribute="bottom" secondItem="Hf0-Ak-1k5" secondAttribute="bottom" constant="150" id="Axa-Mu-QNn"/>
-                                                                    <constraint firstItem="xNN-qO-TFr" firstAttribute="leading" secondItem="sQA-Ei-wcw" secondAttribute="leading" id="MVh-bW-r4P"/>
-                                                                    <constraint firstItem="8wm-Oq-lQZ" firstAttribute="bottom" secondItem="xNN-qO-TFr" secondAttribute="bottom" id="Nyg-xy-ETp"/>
-                                                                    <constraint firstItem="xNN-qO-TFr" firstAttribute="height" secondItem="8wm-Oq-lQZ" secondAttribute="height" id="ShB-lH-DUy"/>
-                                                                    <constraint firstItem="xNN-qO-TFr" firstAttribute="top" secondItem="8wm-Oq-lQZ" secondAttribute="top" id="gWS-9a-A5G"/>
-                                                                    <constraint firstItem="xNN-qO-TFr" firstAttribute="width" secondItem="Hf0-Ak-1k5" secondAttribute="width" id="hkr-wP-pPK"/>
-                                                                    <constraint firstItem="xNN-qO-TFr" firstAttribute="top" secondItem="Hf0-Ak-1k5" secondAttribute="top" id="ssu-fX-e80"/>
-                                                                    <constraint firstAttribute="width" priority="250" constant="390" id="uUP-YX-uPY"/>
-                                                                </constraints>
-                                                                <viewLayoutGuide key="contentLayoutGuide" id="Hf0-Ak-1k5"/>
-                                                                <viewLayoutGuide key="frameLayoutGuide" id="8wm-Oq-lQZ"/>
-                                                            </scrollView>
+                                                            </stackView>
                                                         </subviews>
                                                         <color key="backgroundColor" systemColor="systemBlueColor"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="height" constant="150" id="2pU-1g-SbI"/>
-                                                            <constraint firstAttribute="bottom" secondItem="sQA-Ei-wcw" secondAttribute="bottom" id="EIb-Nr-Wfk"/>
-                                                            <constraint firstItem="sQA-Ei-wcw" firstAttribute="leading" secondItem="sk8-3T-ZZd" secondAttribute="leading" id="RWx-WF-aAN"/>
-                                                            <constraint firstItem="sQA-Ei-wcw" firstAttribute="top" secondItem="sk8-3T-ZZd" secondAttribute="top" id="xIg-lh-uLx"/>
+                                                            <constraint firstAttribute="height" priority="250" constant="150" id="2pU-1g-SbI"/>
+                                                            <constraint firstItem="nnM-J6-6M5" firstAttribute="top" secondItem="sk8-3T-ZZd" secondAttribute="top" id="BZe-Qw-wem"/>
+                                                            <constraint firstAttribute="bottom" secondItem="nnM-J6-6M5" secondAttribute="bottom" id="gDI-FP-gnk"/>
+                                                            <constraint firstAttribute="trailing" secondItem="nnM-J6-6M5" secondAttribute="trailing" id="m1m-7P-b1Z"/>
+                                                            <constraint firstItem="nnM-J6-6M5" firstAttribute="leading" secondItem="sk8-3T-ZZd" secondAttribute="leading" id="wTC-qA-QpO"/>
                                                         </constraints>
                                                     </view>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ABm-ha-DRq">
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vfq-2z-jUe" userLabel="CategorySection">
                                                         <rect key="frame" x="0.0" y="300" width="390" height="150"/>
                                                         <color key="backgroundColor" systemColor="systemCyanColor"/>
                                                         <gestureRecognizers/>
                                                         <constraints>
-                                                            <constraint firstAttribute="height" constant="150" id="7BP-h4-UGc"/>
+                                                            <constraint firstAttribute="height" constant="150" id="AKH-4U-dRb"/>
                                                         </constraints>
                                                     </view>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nu6-g0-jRM" userLabel="View3">
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nu6-g0-jRM" userLabel="CampaignSection">
                                                         <rect key="frame" x="0.0" y="450" width="390" height="150"/>
                                                         <color key="backgroundColor" systemColor="systemYellowColor"/>
                                                         <gestureRecognizers/>
@@ -128,14 +206,14 @@
                                                             <constraint firstAttribute="height" constant="150" id="9EN-WU-vg6"/>
                                                         </constraints>
                                                     </view>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GgM-Yc-UlN" userLabel="View4">
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GgM-Yc-UlN" userLabel="PopularSection">
                                                         <rect key="frame" x="0.0" y="600" width="390" height="150"/>
                                                         <color key="backgroundColor" systemColor="systemTealColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="150" id="UY2-ed-AdS"/>
                                                         </constraints>
                                                     </view>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8hN-Ud-NAs" userLabel="View5">
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8hN-Ud-NAs" userLabel="InfoSection">
                                                         <rect key="frame" x="0.0" y="750" width="390" height="150"/>
                                                         <color key="backgroundColor" systemColor="systemRedColor"/>
                                                         <constraints>
@@ -176,6 +254,7 @@
                             <constraint firstItem="MPc-W7-LH6" firstAttribute="top" secondItem="6Xe-Z7-DZD" secondAttribute="top" id="mhG-uI-gK3"/>
                         </constraints>
                     </view>
+                    <size key="freeformSize" width="390" height="1042"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4gV-6w-TSF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -217,6 +296,9 @@
         </scene>
     </scenes>
     <resources>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
@@ -234,6 +316,9 @@
         </systemColor>
         <systemColor name="systemPinkColor">
             <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemPurpleColor">
+            <color red="0.68627450980392157" green="0.32156862745098042" blue="0.87058823529411766" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemRedColor">
             <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/SnoopClass-IKEA/Base.lproj/Main.storyboard
+++ b/SnoopClass-IKEA/Base.lproj/Main.storyboard
@@ -35,52 +35,13 @@
                                 <rect key="frame" x="0.0" y="47" width="390" height="961"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3Yk-18-p8n" userLabel="ContentView">
-                                        <rect key="frame" x="0.0" y="0.0" width="390" height="850"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="750"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EiS-hE-JsV" userLabel="VerticalStackView">
-                                                <rect key="frame" x="0.0" y="0.0" width="390" height="850"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="390" height="750"/>
                                                 <subviews>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KBh-zB-ivQ" userLabel="SearchSection">
-                                                        <rect key="frame" x="0.0" y="0.0" width="390" height="100"/>
-                                                        <subviews>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="PTd-Xq-qYH">
-                                                                <rect key="frame" x="0.0" y="0.0" width="390" height="100"/>
-                                                                <subviews>
-                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ktr-Zg-0dY" userLabel="SearchTitleView">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="390" height="100"/>
-                                                                        <subviews>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="검색" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cFb-1P-XAF">
-                                                                                <rect key="frame" x="8" y="51.333333333333329" width="59" height="40.666666666666671"/>
-                                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
-                                                                                <nil key="textColor"/>
-                                                                                <nil key="highlightedColor"/>
-                                                                            </label>
-                                                                        </subviews>
-                                                                        <color key="backgroundColor" systemColor="systemCyanColor"/>
-                                                                        <gestureRecognizers/>
-                                                                        <constraints>
-                                                                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="cFb-1P-XAF" secondAttribute="trailing" constant="8" id="41V-hC-3wp"/>
-                                                                            <constraint firstItem="cFb-1P-XAF" firstAttribute="leading" secondItem="Ktr-Zg-0dY" secondAttribute="leadingMargin" id="BbL-sW-C9A"/>
-                                                                            <constraint firstItem="cFb-1P-XAF" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Ktr-Zg-0dY" secondAttribute="top" constant="8" id="SEg-nm-p4u"/>
-                                                                            <constraint firstAttribute="height" priority="750" constant="50" id="r8W-oY-Ao7"/>
-                                                                            <constraint firstAttribute="bottomMargin" secondItem="cFb-1P-XAF" secondAttribute="bottom" id="x7t-Pp-uVh"/>
-                                                                        </constraints>
-                                                                    </view>
-                                                                </subviews>
-                                                            </stackView>
-                                                        </subviews>
-                                                        <color key="backgroundColor" systemColor="systemGreenColor"/>
-                                                        <gestureRecognizers/>
-                                                        <constraints>
-                                                            <constraint firstItem="PTd-Xq-qYH" firstAttribute="leading" secondItem="KBh-zB-ivQ" secondAttribute="leading" id="8h0-Lw-cva"/>
-                                                            <constraint firstAttribute="height" priority="750" constant="100" id="GZz-dE-Tx9"/>
-                                                            <constraint firstItem="PTd-Xq-qYH" firstAttribute="top" secondItem="KBh-zB-ivQ" secondAttribute="top" id="TFW-wy-BvW"/>
-                                                            <constraint firstAttribute="trailing" secondItem="PTd-Xq-qYH" secondAttribute="trailing" id="Wh4-LV-eWC"/>
-                                                            <constraint firstAttribute="bottom" secondItem="PTd-Xq-qYH" secondAttribute="bottom" id="sTK-NV-y4q"/>
-                                                        </constraints>
-                                                    </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sk8-3T-ZZd" userLabel="RecentSection">
-                                                        <rect key="frame" x="0.0" y="100" width="390" height="150"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="390" height="150"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="nnM-J6-6M5" userLabel="SubStackView">
                                                                 <rect key="frame" x="0.0" y="0.0" width="390" height="150"/>
@@ -89,7 +50,7 @@
                                                                         <rect key="frame" x="0.0" y="0.0" width="390" height="50"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="최근 본 제품" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9r0-Gb-j21">
-                                                                                <rect key="frame" x="8" y="15.666666666666655" width="105.33333333333333" height="26.333333333333329"/>
+                                                                                <rect key="frame" x="8" y="15.666666666666663" width="105.33333333333333" height="26.333333333333329"/>
                                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -174,7 +135,7 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vfq-2z-jUe" userLabel="CategorySection">
-                                                        <rect key="frame" x="0.0" y="250" width="390" height="150"/>
+                                                        <rect key="frame" x="0.0" y="150" width="390" height="150"/>
                                                         <color key="backgroundColor" systemColor="systemCyanColor"/>
                                                         <gestureRecognizers/>
                                                         <constraints>
@@ -182,7 +143,7 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nu6-g0-jRM" userLabel="CampaignSection">
-                                                        <rect key="frame" x="0.0" y="400" width="390" height="150"/>
+                                                        <rect key="frame" x="0.0" y="300" width="390" height="150"/>
                                                         <color key="backgroundColor" systemColor="systemYellowColor"/>
                                                         <gestureRecognizers/>
                                                         <constraints>
@@ -190,14 +151,14 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GgM-Yc-UlN" userLabel="PopularSection">
-                                                        <rect key="frame" x="0.0" y="550" width="390" height="150"/>
+                                                        <rect key="frame" x="0.0" y="450" width="390" height="150"/>
                                                         <color key="backgroundColor" systemColor="systemTealColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="150" id="UY2-ed-AdS"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8hN-Ud-NAs" userLabel="InfoSection">
-                                                        <rect key="frame" x="0.0" y="700" width="390" height="150"/>
+                                                        <rect key="frame" x="0.0" y="600" width="390" height="150"/>
                                                         <color key="backgroundColor" systemColor="systemRedColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="150" id="2kf-hS-TMx"/>
@@ -240,46 +201,11 @@
                     <size key="freeformSize" width="390" height="1042"/>
                     <connections>
                         <outlet property="recentHorizontalStackView" destination="9K7-56-rqG" id="3IC-RP-vK7"/>
-                        <outlet property="searchStackView" destination="PTd-Xq-qYH" id="Jl3-Ub-o6K"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4gV-6w-TSF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="840" y="-10.663507109004739"/>
-        </scene>
-        <!--VC3-->
-        <scene sceneID="I1o-BO-LQP">
-            <objects>
-                <viewController storyboardIdentifier="VC3" id="hex-k1-LkG" customClass="VC3" customModule="SnoopClass_IKEA" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="T2L-Ay-Hq4">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="asdfasdfsadf" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZWQ-h3-AGa">
-                                <rect key="frame" x="0.0" y="418.33333333333331" width="390" height="20.333333333333314"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="hKl-k1-pTn"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                        </subviews>
-                        <viewLayoutGuide key="safeArea" id="rvg-fb-vpR"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <constraints>
-                            <constraint firstItem="ZWQ-h3-AGa" firstAttribute="centerY" secondItem="rvg-fb-vpR" secondAttribute="centerY" id="OLZ-RT-Z5u"/>
-                            <constraint firstItem="ZWQ-h3-AGa" firstAttribute="leading" secondItem="rvg-fb-vpR" secondAttribute="leading" id="Xps-xb-0Ye"/>
-                            <constraint firstItem="rvg-fb-vpR" firstAttribute="trailing" secondItem="ZWQ-h3-AGa" secondAttribute="trailing" id="gek-1e-3lI"/>
-                        </constraints>
-                    </view>
-                    <connections>
-                        <outlet property="textlabel" destination="ZWQ-h3-AGa" id="5Ih-uT-1MH"/>
-                    </connections>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="hTx-Ep-TUN" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="1760" y="-26.303317535545023"/>
         </scene>
     </scenes>
     <resources>
@@ -294,9 +220,6 @@
         </systemColor>
         <systemColor name="systemCyanColor">
             <color red="0.19607843137254902" green="0.67843137254901964" blue="0.90196078431372551" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="systemGreenColor">
-            <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemPinkColor">
             <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/SnoopClass-IKEA/Base.lproj/Main.storyboard
+++ b/SnoopClass-IKEA/Base.lproj/Main.storyboard
@@ -35,22 +35,22 @@
                                 <rect key="frame" x="0.0" y="47" width="390" height="961"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3Yk-18-p8n" userLabel="ContentView">
-                                        <rect key="frame" x="0.0" y="0.0" width="390" height="900"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="850"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EiS-hE-JsV" userLabel="VerticalStackView">
-                                                <rect key="frame" x="0.0" y="0.0" width="390" height="900"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="390" height="850"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KBh-zB-ivQ" userLabel="SearchSection">
-                                                        <rect key="frame" x="0.0" y="0.0" width="390" height="150"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="390" height="100"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="PTd-Xq-qYH">
-                                                                <rect key="frame" x="0.0" y="0.0" width="390" height="150"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="390" height="100"/>
                                                                 <subviews>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ktr-Zg-0dY" userLabel="SearchTitleView">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="390" height="50"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="390" height="100"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="검색" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cFb-1P-XAF">
-                                                                                <rect key="frame" x="8" y="8" width="59" height="34"/>
+                                                                                <rect key="frame" x="8" y="51.333333333333329" width="59" height="40.666666666666671"/>
                                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -66,14 +66,6 @@
                                                                             <constraint firstAttribute="bottomMargin" secondItem="cFb-1P-XAF" secondAttribute="bottom" id="x7t-Pp-uVh"/>
                                                                         </constraints>
                                                                     </view>
-                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6Wi-oD-PwQ" userLabel="SearchBarView">
-                                                                        <rect key="frame" x="0.0" y="50" width="390" height="100"/>
-                                                                        <color key="backgroundColor" systemColor="systemGreenColor"/>
-                                                                        <gestureRecognizers/>
-                                                                        <constraints>
-                                                                            <constraint firstAttribute="height" priority="250" constant="100" id="9N6-YK-Eka"/>
-                                                                        </constraints>
-                                                                    </view>
                                                                 </subviews>
                                                             </stackView>
                                                         </subviews>
@@ -81,14 +73,14 @@
                                                         <gestureRecognizers/>
                                                         <constraints>
                                                             <constraint firstItem="PTd-Xq-qYH" firstAttribute="leading" secondItem="KBh-zB-ivQ" secondAttribute="leading" id="8h0-Lw-cva"/>
-                                                            <constraint firstAttribute="height" constant="150" id="GZz-dE-Tx9"/>
+                                                            <constraint firstAttribute="height" priority="750" constant="100" id="GZz-dE-Tx9"/>
                                                             <constraint firstItem="PTd-Xq-qYH" firstAttribute="top" secondItem="KBh-zB-ivQ" secondAttribute="top" id="TFW-wy-BvW"/>
                                                             <constraint firstAttribute="trailing" secondItem="PTd-Xq-qYH" secondAttribute="trailing" id="Wh4-LV-eWC"/>
                                                             <constraint firstAttribute="bottom" secondItem="PTd-Xq-qYH" secondAttribute="bottom" id="sTK-NV-y4q"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sk8-3T-ZZd" userLabel="RecentSection">
-                                                        <rect key="frame" x="0.0" y="150" width="390" height="150"/>
+                                                        <rect key="frame" x="0.0" y="100" width="390" height="150"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="nnM-J6-6M5" userLabel="SubStackView">
                                                                 <rect key="frame" x="0.0" y="0.0" width="390" height="150"/>
@@ -129,10 +121,10 @@
                                                                         <rect key="frame" x="0.0" y="50" width="390" height="100"/>
                                                                         <subviews>
                                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xNN-qO-TFr" userLabel="RecentContentView">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="500" height="100"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="250" height="100"/>
                                                                                 <subviews>
                                                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9K7-56-rqG">
-                                                                                        <rect key="frame" x="0.0" y="0.0" width="500" height="100"/>
+                                                                                        <rect key="frame" x="0.0" y="0.0" width="250" height="100"/>
                                                                                         <subviews>
                                                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WQx-Wh-iO6">
                                                                                                 <rect key="frame" x="0.0" y="0.0" width="250" height="100"/>
@@ -140,15 +132,6 @@
                                                                                                 <constraints>
                                                                                                     <constraint firstAttribute="width" constant="250" id="Ru5-bX-hPO"/>
                                                                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="250" id="vcA-3o-6Qo"/>
-                                                                                                </constraints>
-                                                                                            </view>
-                                                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bbE-Ka-sez">
-                                                                                                <rect key="frame" x="250" y="0.0" width="250" height="100"/>
-                                                                                                <color key="backgroundColor" systemColor="systemOrangeColor"/>
-                                                                                                <constraints>
-                                                                                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="250" id="RM1-by-Oa7"/>
-                                                                                                    <constraint firstAttribute="width" constant="250" id="irH-OO-cqM"/>
-                                                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="250" id="zOX-UL-sbU"/>
                                                                                                 </constraints>
                                                                                             </view>
                                                                                         </subviews>
@@ -191,7 +174,7 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vfq-2z-jUe" userLabel="CategorySection">
-                                                        <rect key="frame" x="0.0" y="300" width="390" height="150"/>
+                                                        <rect key="frame" x="0.0" y="250" width="390" height="150"/>
                                                         <color key="backgroundColor" systemColor="systemCyanColor"/>
                                                         <gestureRecognizers/>
                                                         <constraints>
@@ -199,7 +182,7 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nu6-g0-jRM" userLabel="CampaignSection">
-                                                        <rect key="frame" x="0.0" y="450" width="390" height="150"/>
+                                                        <rect key="frame" x="0.0" y="400" width="390" height="150"/>
                                                         <color key="backgroundColor" systemColor="systemYellowColor"/>
                                                         <gestureRecognizers/>
                                                         <constraints>
@@ -207,14 +190,14 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GgM-Yc-UlN" userLabel="PopularSection">
-                                                        <rect key="frame" x="0.0" y="600" width="390" height="150"/>
+                                                        <rect key="frame" x="0.0" y="550" width="390" height="150"/>
                                                         <color key="backgroundColor" systemColor="systemTealColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="150" id="UY2-ed-AdS"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8hN-Ud-NAs" userLabel="InfoSection">
-                                                        <rect key="frame" x="0.0" y="750" width="390" height="150"/>
+                                                        <rect key="frame" x="0.0" y="700" width="390" height="150"/>
                                                         <color key="backgroundColor" systemColor="systemRedColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="150" id="2kf-hS-TMx"/>
@@ -255,6 +238,10 @@
                         </constraints>
                     </view>
                     <size key="freeformSize" width="390" height="1042"/>
+                    <connections>
+                        <outlet property="recentHorizontalStackView" destination="9K7-56-rqG" id="3IC-RP-vK7"/>
+                        <outlet property="searchStackView" destination="PTd-Xq-qYH" id="Jl3-Ub-o6K"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4gV-6w-TSF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -310,9 +297,6 @@
         </systemColor>
         <systemColor name="systemGreenColor">
             <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="systemOrangeColor">
-            <color red="1" green="0.58431372549019611" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemPinkColor">
             <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/SnoopClass-IKEA/SearchViewController.swift
+++ b/SnoopClass-IKEA/SearchViewController.swift
@@ -11,15 +11,53 @@ class SearchViewController: UIViewController {
     fileprivate var recent, category: CompactCard?
     fileprivate var campaign, popular: DetailCard?
 
+    @IBOutlet weak var searchStackView: UIStackView!
+    @IBOutlet weak var recentHorizontalStackView: UIStackView!
+    private var searchController: UISearchController = {
+        return UISearchController(searchResultsController: SearchResultViewController())
+    }()
+
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
         readFile()
+        configSearchController()
+        configRecentSection()
+    }
+}
+
+extension SearchViewController {
+    private func configSearchController() {
+        searchController.delegate = self
+        searchController.searchBar.delegate = self
+
+        searchController.searchBar.placeholder = "무엇을 찾고 있나요?"
+        searchController.searchBar.setImage(UIImage(systemName: "magnifyingglass"), for: UISearchBar.Icon.search, state: .normal)
+        searchController.searchBar.backgroundColor = .systemBackground
+        searchController.searchBar.searchTextField.layer.cornerRadius = 16
+        searchController.searchBar.searchTextField.clipsToBounds = true
+        searchStackView.addArrangedSubview(searchController.searchBar)
+    }
+    private func configRecentSection() {
+        recentHorizontalStackView.backgroundColor = .systemBlue
+        let sourceImage = UIImage(named: "temp-item")!
+        print(sourceImage.size)
+
+        for _ in 0...2 {
+            let atest = UIImageView(image: sourceImage)
+            atest.layer.borderColor = UIColor.systemYellow.cgColor
+            atest.layer.borderWidth = 3
+            atest.contentMode = .scaleAspectFit
+            
+            // atest.layer.cornerRadius = atest.frame.size.height/2
+            atest.clipsToBounds = true
+            recentHorizontalStackView.addArrangedSubview(atest)
+        }
     }
 }
 
 // 참고 코드: https://alep.medium.com/swiftui-tutorial-how-to-read-a-json-file-73fd960ec954
-extension SearchViewController {
+extension SearchViewController: UISearchBarDelegate, UISearchControllerDelegate {
     fileprivate func readFile() {
         if let url = Bundle.main.url(forResource: "ikeaSearchViewMockData", withExtension: "json"),
            let data = try? Data(contentsOf: url) {

--- a/SnoopClass-IKEA/SearchViewController.swift
+++ b/SnoopClass-IKEA/SearchViewController.swift
@@ -11,7 +11,6 @@ class SearchViewController: UIViewController {
     fileprivate var recent, category: CompactCard?
     fileprivate var campaign, popular: DetailCard?
 
-    @IBOutlet weak var searchStackView: UIStackView!
     @IBOutlet weak var recentHorizontalStackView: UIStackView!
     private var searchController: UISearchController = {
         return UISearchController(searchResultsController: SearchResultViewController())
@@ -20,14 +19,19 @@ class SearchViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
-        readFile()
-        configSearchController()
+        // readFile()
+        configSearchSection()
         configRecentSection()
     }
 }
 
 extension SearchViewController {
-    private func configSearchController() {
+    private func configSearchSection() {
+        navigationItem.titleView = searchController.searchBar
+        navigationController?.navigationBar.prefersLargeTitles = true
+        title = "검색"
+        navigationItem.searchController = searchController
+
         searchController.delegate = self
         searchController.searchBar.delegate = self
 
@@ -36,7 +40,6 @@ extension SearchViewController {
         searchController.searchBar.backgroundColor = .systemBackground
         searchController.searchBar.searchTextField.layer.cornerRadius = 16
         searchController.searchBar.searchTextField.clipsToBounds = true
-        searchStackView.addArrangedSubview(searchController.searchBar)
     }
     private func configRecentSection() {
         recentHorizontalStackView.backgroundColor = .systemBlue

--- a/SnoopClass-IKEA/SearchViewController.swift
+++ b/SnoopClass-IKEA/SearchViewController.swift
@@ -15,10 +15,7 @@ class SearchViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
         readFile()
-        // Do any additional setup after loading the view.
     }
-
-
 }
 
 // 참고 코드: https://alep.medium.com/swiftui-tutorial-how-to-read-a-json-file-73fd960ec954

--- a/SnoopClass-IKEA/SmallClasses.swift
+++ b/SnoopClass-IKEA/SmallClasses.swift
@@ -1,0 +1,44 @@
+//
+//  SmallClasses.swift
+//  SnoopClass-IKEA
+//
+//  Created by Hyorim Nam on 2022/10/11.
+//
+
+import UIKit
+
+class SearchResultViewController: UIViewController {
+//    private var searchText = "asdf"
+//    private let text = UILabel()
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemYellow
+//        text.text = searchText
+//        text.font = .preferredFont(forTextStyle: .largeTitle)
+//        text.translatesAutoresizingMaskIntoConstraints = false
+//        view.addSubview(text)
+//
+//        NSLayoutConstraint.activate([
+//            text.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+//            text.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+//        ])
+    }
+}
+
+// 출처: https://nsios.tistory.com/154 // wwdc18일지도
+extension UIImage {
+    func resize(newWidth: CGFloat) -> UIImage {
+        let scale = newWidth / self.size.width
+        let newHeight = self.size.height * scale
+
+        let size = CGSize(width: newWidth, height: newHeight)
+        let render = UIGraphicsImageRenderer(size: size)
+        let renderImage = render.image { context in
+            self.draw(in: CGRect(origin: .zero, size: size))
+        }
+        
+        print("화면 배율: \(UIScreen.main.scale)")// 배수
+        print("origin: \(self), resize: \(renderImage)")
+        return renderImage
+    }
+}

--- a/SnoopClass-IKEA/TabBarController.swift
+++ b/SnoopClass-IKEA/TabBarController.swift
@@ -27,9 +27,7 @@ class TabBarController: UITabBarController {
     private lazy var searchViewController: UINavigationController = {
         let viewController = storyboard!.instantiateViewController(withIdentifier: "SearchViewController")
         viewController.tabBarItem = UITabBarItem(title: nil, image: UIImage(systemName: TabIcon.search.rawValue), tag: 1)
-        let naviController = UINavigationController(rootViewController: viewController)
-        naviController.setNavigationBarHidden(true, animated: true)
-        return naviController
+        return UINavigationController(rootViewController: viewController)
     }()
     private lazy var userViewController: UIViewController = {
         $0.view.backgroundColor = .systemMint

--- a/SnoopClass-IKEA/TabBarController.swift
+++ b/SnoopClass-IKEA/TabBarController.swift
@@ -25,7 +25,7 @@ class TabBarController: UITabBarController {
     }(UIViewController())
     // 상품 상세페이지로 이동시 네비게이션컨트롤러를 사용하므로 미리 넣음
     private lazy var searchViewController: UINavigationController = {
-        let viewController = SearchViewController()
+        let viewController = storyboard!.instantiateViewController(withIdentifier: "SearchViewController")
         viewController.tabBarItem = UITabBarItem(title: nil, image: UIImage(systemName: TabIcon.search.rawValue), tag: 1)
         return UINavigationController(rootViewController: viewController)
     }()

--- a/SnoopClass-IKEA/TabBarController.swift
+++ b/SnoopClass-IKEA/TabBarController.swift
@@ -27,7 +27,9 @@ class TabBarController: UITabBarController {
     private lazy var searchViewController: UINavigationController = {
         let viewController = storyboard!.instantiateViewController(withIdentifier: "SearchViewController")
         viewController.tabBarItem = UITabBarItem(title: nil, image: UIImage(systemName: TabIcon.search.rawValue), tag: 1)
-        return UINavigationController(rootViewController: viewController)
+        let naviController = UINavigationController(rootViewController: viewController)
+        naviController.setNavigationBarHidden(true, animated: true)
+        return naviController
     }()
     private lazy var userViewController: UIViewController = {
         $0.view.backgroundColor = .systemMint


### PR DESCRIPTION
검색 섹션 위치 잡았습니다

## 관련 이슈
#3 

## 배경

## 작업 내용
- [x] 섹션별 스택뷰
- [x] 검색섹션 UI
  - [ ] 커스텀 
- [ ] 최근 섹션에 동그란 이미지 넣기
- [ ] 최근 섹션 뷰 지우기
- [ ] 정보 다른 뷰에 넘기기
- [x] 스크롤 2개 작동하도록

### 스크린샷
![Simulator Screen Shot - iPhone 14 - 2022-10-12 at 09 26 57](https://user-images.githubusercontent.com/18394923/195222014-796fc2e5-1266-4617-8ba0-4911733a861c.png)

<!--
이하는 꼭 채울 내용은 아님. 제목도 유동적으로 쓰기.
-->
## 리뷰 포인트
<!--
고민한 내용, 질문
-->
- 리사이즈 못하고 있음
- 검색창 눌렀을 때 검색창 사라짐
## 참고
